### PR TITLE
fix: incorrect parameters V2 motion sensor

### DIFF
--- a/app.json
+++ b/app.json
@@ -2567,6 +2567,7 @@
       "class": "homealarm",
       "capabilities": [
         "alarm_motion",
+        "alarm_tamper",
         "measure_battery"
       ],
       "energy": {
@@ -2592,15 +2593,13 @@
         "learnmode": {
           "image": "/drivers/Motion Sensor v2/assets/learnmode.svg",
           "instruction": {
-            "en": "Remove and replace the battery again and attach the cover to enter inclusion mode (2).\n\nMake sure you have the Device Specific Key (DSK) at hand, the device will reset itself when not entered within 1 minute.",
-            "nl": "Haal de batterij er weer uit, plaats terug en monteer de kap om de integratie mode te starten (2).\n\nZorg ervoor dat je de Device Specific Key (DSK) bij de hand hebt, het apparaat zal zich resetten als de Key niet binnen 1 minuut ingegeven wordt."
+            "en": "Make sure you have the 5-digit DSK PIN found on the package or under the QR code printed on the device.\n\nPress and hold the button on the front of the device for ~3 seconds. The LED will blink green three times followed by a brief pause."
           }
         },
         "unlearnmode": {
           "image": "/drivers/Motion Sensor v2/assets/learnmode.svg",
           "instruction": {
-            "en": "Press the cover release to access the battery, remove and replace the battery to reset the device.",
-            "nl": "Druk op de clip en verwijder de kap om de batterij er uit te halen en weer in te doen om de detector te resetten."
+            "en": "Locate the pinhole reset button on the back of the device in the battery compartment. Use a paper clip or similar object and tap the pinhole button. The LED turns on solid red to indicate the device was removed from the network."
           }
         },
         "wakeUpInterval": 0,
@@ -2613,88 +2612,199 @@
         {
           "type": "group",
           "label": {
-            "en": "Device specific"
+            "en": "Motion Deletion"
           },
           "children": [
             {
-              "id": "alarmMotionResetWindow",
-              "type": "number",
+              "id": "motionDetectionMode",
               "label": {
-                "en": "Disable motion alarm after",
-                "nl": "Schakel bewegingsalarm uit na"
+                "en": "Mode/Sensitivity"
               },
-              "hint": {
-                "en": "This setting will disable the motion alarm after the given time (in minutes) has expired. Every time motion is observed by the device it will reset this timeout.\n\nDefault: 3 minutes",
-                "nl": "Deze instelling zal het bewegingsalarm uitschakelen na de tijd (in minuten) is verstreken. Elke keer dat opnieuw beweging wordt gedetecteerd wordt deze timer herstart.\n\nStandaard: 3 minuten"
+              "zwave": {
+                "index": 9,
+                "size": 1
               },
+              "type": "number",
               "value": 3,
               "attr": {
-                "min": 1,
-                "max": 9
+                "min": 0,
+                "max": 4
               },
-              "units": {
-                "en": "min.",
-                "nl": "min."
+              "hint": {
+                "en": "Change the mode/sensitivity between 5 modes"
               }
             },
             {
-              "id": "sensorSensitivity",
-              "type": "dropdown",
+              "id": "anyMotionThreshold",
               "label": {
-                "en": "Pet Immunity",
-                "nl": "Huisdier detectie immuniteit"
+                "en": "Detection Threshold"
               },
-              "hint": {
-                "en": "Configures the “Pet Immunity,” or sensitivity of the motion detection used mostly so only human motion is detected.\n\nDefault: 15kg (33lb)",
-                "nl": "Configures the “Pet Immunity,” or sensitivity of the motion detection used mostly so only human motion is detected.\n\nDefault: 15kg (33lb)"
-              },
-              "value": "1",
-              "values": [
-                {
-                  "id": "0",
-                  "label": {
-                    "en": "No pet immunity"
-                  }
-                },
-                {
-                  "id": "1",
-                  "label": {
-                    "en": "15kg (33lb)"
-                  }
-                },
-                {
-                  "id": "2",
-                  "label": {
-                    "en": "25kg (55lb)"
-                  }
-                }
-              ]
-            },
-            {
-              "id": "batteryReportInterval",
               "zwave": {
-                "index": 1,
-                "size": 2
+                "index": 10,
+                "size": 1,
+                "signed": false
               },
               "type": "number",
-              "value": 4200,
+              "value": 128,
               "attr": {
-                "min": 255,
-                "max": 4200
+                "min": 0,
+                "max": 255
+              }
+            }
+          ]
+        },
+        {
+          "type": "group",
+          "label": {
+            "en": "Motion Reset Delays"
+          },
+          "children": [
+            {
+              "id": "standardClearDelay",
+              "label": {
+                "en": "Standard Reset Delay"
+              },
+              "zwave": {
+                "index": 8,
+                "size": 1,
+                "signed": false
+              },
+              "type": "number",
+              "value": 10,
+              "attr": {
+                "min": 10,
+                "max": 255
               },
               "units": {
-                "en": "sec.",
-                "nl": "sec."
-              },
-              "label": {
-                "en": "Battery Report Interval",
-                "nl": "Battery Rapporttage Interval"
+                "en": "seconds"
               },
               "hint": {
-                "en": "The interval between battery reports. \n\nDefault: 4200 seconds (70 minuten).",
-                "nl": "De tijdsduur tussen batterij rapporten. \n\nStandaard: 4200 seconds (70 minuten)."
+                "en": "Delay time in seconds for standard motion signal to clear.\n\nDefault: 10 sec."
+              }
+            },
+            {
+              "id": "occupancyClearDelay",
+              "label": {
+                "en": "Occupancy Reset Delay"
               },
-              "_size": 2
+              "zwave": {
+                "index": 6,
+                "size": 1,
+                "signed": false
+              },
+              "type": "number",
+              "value": 5,
+              "attr": {
+                "min": 0,
+                "max": 255
+              },
+              "units": {
+                "en": "seconds"
+              },
+              "hint": {
+                "en": "Delay time in seconds for occupancy signal to clear.\n\nDefault: 0 sec."
+              }
+            },
+            {
+              "id": "intrusionClearDelay",
+              "label": {
+                "en": "Intrusion Reset Delay"
+              },
+              "zwave": {
+                "index": 7,
+                "size": 1,
+                "signed": false
+              },
+              "type": "number",
+              "value": 5,
+              "attr": {
+                "min": 5,
+                "max": 255
+              },
+              "units": {
+                "en": "seconds"
+              },
+              "hint": {
+                "en": "Delay time in seconds for intrusion signal to clear.\n\nDefault: 5 sec."
+              }
+            }
+          ]
+        },
+        {
+          "type": "group",
+          "label": {
+            "en": "LED Notifications"
+          },
+          "children": [
+            {
+              "id": "lightingEnabled",
+              "label": {
+                "en": "Enabled on Detection"
+              },
+              "zwave": {
+                "index": 11,
+                "size": 1,
+                "signed": false
+              },
+              "type": "checkbox",
+              "value": false,
+              "hint": {
+                "en": "When enabled the LED light will turn green when motion is detected."
+              }
+            },
+            {
+              "id": "lightingDelay",
+              "label": {
+                "en": "Turn Off Delay"
+              },
+              "zwave": {
+                "index": 12,
+                "size": 1,
+                "signed": false
+              },
+              "type": "number",
+              "units": {
+                "en": "seconds"
+              },
+              "attr": {
+                "min": 0,
+                "max": 255
+              },
+              "value": 20,
+              "hint": {
+                "en": "Delay in seconds after which the LED light will turn off."
+              }
+            }
+          ]
+        },
+        {
+          "type": "group",
+          "label": {
+            "en": "Power"
+          },
+          "children": [
+            {
+              "id": "heartbeatInterval",
+              "label": {
+                "en": "Battery Report Interval"
+              },
+              "zwave": {
+                "index": 1,
+                "size": 1,
+                "signed": false
+              },
+              "type": "number",
+              "value": 70,
+              "attr": {
+                "min": 1,
+                "max": 70
+              },
+              "units": {
+                "en": "minutes"
+              },
+              "hint": {
+                "en": "The interval between battery level reports. \n\nDefault: 70 minutes."
+              }
             }
           ]
         }

--- a/drivers/Motion Sensor v2/device.js
+++ b/drivers/Motion Sensor v2/device.js
@@ -2,31 +2,88 @@
 
 const { ZwaveDevice } = require('homey-zwavedriver');
 
-class RingDevice extends ZwaveDevice {
+/**
+ * Enum representing the types of reports.
+ * @enum {string}
+ * @readonly
+ * @property {string} homeSecurity - Home Security report type.
+ * @property {string} system - System report type.
+ */
+const ReportTypes = {
+  homeSecurity: 'Home Security',
+  system: 'System',
+  powerManagement: 'Power Management'
+};
 
-  async onNodeInit() {
-    // this.enableDebug();
-    // this.printNode();
+/**
+ * Enum representing the state of a reported event.
+ * @enum {number}
+ */
+const ReportEventId = {
+  clear: 0,
+  sensorCaseRemoved: 3,
+  commButtonPressed: 5,
+  intrusion: 8
+};
 
+export default class extends ZwaveDevice {
+
+  /**
+   * The state of the device.
+   * @type {number}
+   */
+  state;
+
+  /**
+   * Initializes the capabilities and listeners for the Ring Motion Detector Gen 2.
+   */
+  onNodeInit() {
     // register Homey's capabilities with Z-Wave COMMAND CLASSES
     this.registerCapability('measure_battery', 'BATTERY');
 
     // register listener for NOTIFICATION REPORT
-    this.registerReportListener('NOTIFICATION', 'NOTIFICATION_REPORT', report =>  {
-      //this.log(report);
-      switch (report['Notification Type']) {
-        case "Home Security":
-          if ( report['Event'] == 8 ) {
-            this.setCapabilityValue('alarm_motion', true)
-          } else if ( report['Event'] == 0 ) {
-            this.setCapabilityValue('alarm_motion', false)
-          }
-          break;
-      }
-    });
+    this.registerReportListener('NOTIFICATION', 'NOTIFICATION_REPORT', this.onNotificationReport.bind(this));
 
-    this.log(`Ring Motion Detector "${this.getName()}" capabilities have been initialized`);
+    // Log that the device has been initialized
+    this.log(`Ring Motion Detector Gen 2 "${this.getName()}" capabilities have been initialized`);
+  }
+
+  /**
+   * Handles the notification report received from the motion sensor.
+   * @param {Report} report - The notification report object.
+   */
+  onNotificationReport(report) {
+    switch(report['Notification Type']) {
+      case ReportTypes.homeSecurity: this.onHomeSecurityReport(report); break;
+      case ReportTypes.system: this.onSystemReport(report); break;
+      case ReportTypes.powerManagement: this.onPowerManagementReport(report); break;
+      default: this.log('Unhandled notification report:', report);
+    }
+  }
+
+  onHomeSecurityReport(report) {
+    this.log('Home security report received:', report);
+    if (this.state !== 0 && report['Event'] === ReportEventId.clear) {
+      if (this.state === ReportEventId.intrusion) {
+        this.setCapabilityValue('alarm_motion', false);
+      } else if (this.state === ReportEventId.sensorCaseRemoved) {
+        this.setCapabilityValue('alarm_tamper', false);
+      }
+      this.state = 0;
+    } else if (report['Event'] === ReportEventId.intrusion) {
+      this.setCapabilityValue('alarm_motion', true);
+      this.state = ReportEventId.intrusion;
+    } else if (report['Event'] === ReportEventId.sensorCaseRemoved) {
+      this.setCapabilityValue('alarm_tamper', true);
+      this.state = ReportEventId.sensorCaseRemoved;
+    }
+  }
+
+  onSystemReport(report) {
+    this.log('System report received:', report);
+  }
+
+  onPowerManagementReport(report) {
+    this.log('Power management report received:', report);
   }
 }
-
-module.exports = RingDevice;

--- a/drivers/Motion Sensor v2/driver.compose.json
+++ b/drivers/Motion Sensor v2/driver.compose.json
@@ -7,6 +7,7 @@
   "class": "homealarm",
   "capabilities": [
     "alarm_motion",
+    "alarm_tamper",
     "measure_battery"
   ],
   "energy": {

--- a/drivers/Motion Sensor v2/driver.compose.json
+++ b/drivers/Motion Sensor v2/driver.compose.json
@@ -26,15 +26,13 @@
     "learnmode": {
       "image": "{{driverAssetsPath}}/learnmode.svg",
       "instruction": {
-        "en": "Remove and replace the battery again and attach the cover to enter inclusion mode (2).\n\nMake sure you have the Device Specific Key (DSK) at hand, the device will reset itself when not entered within 1 minute.",
-        "nl": "Haal de batterij er weer uit, plaats terug en monteer de kap om de integratie mode te starten (2).\n\nZorg ervoor dat je de Device Specific Key (DSK) bij de hand hebt, het apparaat zal zich resetten als de Key niet binnen 1 minuut ingegeven wordt."
+        "en": "Make sure you have the 5-digit DSK PIN found on the package or under the QR code printed on the device.\n\nPress and hold the button on the front of the device for ~3 seconds. The LED will blink green three times followed by a brief pause."
       }
     },
     "unlearnmode": {
       "image": "{{driverAssetsPath}}/learnmode.svg",
       "instruction": {
-        "en": "Press the cover release to access the battery, remove and replace the battery to reset the device.",
-        "nl": "Druk op de clip en verwijder de kap om de batterij er uit te halen en weer in te doen om de detector te resetten."
+        "en": "Locate the pinhole reset button on the back of the device in the battery compartment. Use a paper clip or similar object and tap the pinhole button. The LED turns on solid red to indicate the device was removed from the network."
       }
     },
     "wakeUpInterval": 0,

--- a/drivers/Motion Sensor v2/driver.settings.compose.json
+++ b/drivers/Motion Sensor v2/driver.settings.compose.json
@@ -17,7 +17,7 @@
       {
         "id": "anyMotionThreshold",
         "label": { "en": "Detection Threshold" },
-        "zwave": { "index": 10, "size": 1 },
+        "zwave": { "index": 10, "size": 1, "signed": false },
         "type": "number",
         "value": 128,
         "attr": { "min": 0, "max": 255 }
@@ -31,7 +31,7 @@
       {
         "id": "standardClearDelay",
         "label": { "en": "Standard Reset Delay" },
-        "zwave": { "index": 8, "size": 1 },
+        "zwave": { "index": 8, "size": 1, "signed": false },
         "type": "number",
         "value": 10,
         "attr": { "min": 10, "max": 255 },
@@ -43,7 +43,7 @@
       {
         "id": "occupancyClearDelay",
         "label": { "en": "Occupancy Reset Delay" },
-        "zwave": { "index": 6, "size": 1 },
+        "zwave": { "index": 6, "size": 1, "signed": false },
         "type": "number",
         "value": 5,
         "attr": { "min": 0, "max": 255 },
@@ -55,7 +55,7 @@
       {
         "id": "intrusionClearDelay",
         "label": { "en": "Intrusion Reset Delay" },
-        "zwave": { "index": 7, "size": 1 },
+        "zwave": { "index": 7, "size": 1, "signed": false },
         "type": "number",
         "value": 5,
         "attr": { "min": 5, "max": 255 },
@@ -73,8 +73,8 @@
       {
         "id": "lightingEnabled",
         "label": { "en": "Enabled on Detection" },
-        "zwave": { "index": 11, "size": 1 },
-        "type": "Checkbox",
+        "zwave": { "index": 11, "size": 1, "signed": false },
+        "type": "checkbox",
         "value": false,
         "hint": {
           "en": "When enabled the LED light will turn green when motion is detected."
@@ -83,11 +83,11 @@
       {
         "id": "lightingDelay",
         "label": { "en": "Turn Off Delay" },
-        "zwave": { "index": 12, "size": 1 },
+        "zwave": { "index": 12, "size": 1, "signed": false },
         "type": "number",
         "units": { "en": "seconds" },
         "attr": { "min": 0, "max": 255 },
-        "value": false,
+        "value": 20,
         "hint": {
           "en": "Delay in seconds after which the LED light will turn off."
         }
@@ -101,7 +101,7 @@
       {
         "id": "heartbeatInterval",
         "label": { "en": "Battery Report Interval" },
-        "zwave": { "index": 1, "size": 1 },
+        "zwave": { "index": 1, "size": 1, "signed": false },
         "type": "number",
         "value": 70,
         "attr": { "min": 1, "max": 70 },

--- a/drivers/Motion Sensor v2/driver.settings.compose.json
+++ b/drivers/Motion Sensor v2/driver.settings.compose.json
@@ -1,91 +1,113 @@
 [
   {
     "type": "group",
-    "label": {
-      "en": "Device specific"
-    },
+    "label": { "en": "Motion Deletion" },
     "children": [
       {
-        "id": "alarmMotionResetWindow",
+        "id": "motionDetectionMode",
+        "label": { "en": "Mode/Sensitivity" },
+        "zwave": { "index": 9, "size": 1 },
         "type": "number",
-        "label": {
-          "en": "Disable motion alarm after",
-          "nl": "Schakel bewegingsalarm uit na"
-        },
-        "hint": {
-          "en": "This setting will disable the motion alarm after the given time (in minutes) has expired. Every time motion is observed by the device it will reset this timeout.\n\nDefault: 3 minutes",
-          "nl": "Deze instelling zal het bewegingsalarm uitschakelen na de tijd (in minuten) is verstreken. Elke keer dat opnieuw beweging wordt gedetecteerd wordt deze timer herstart.\n\nStandaard: 3 minuten"
-        },
         "value": 3,
-        "attr": {
-          "min": 1,
-          "max": 9
-        },
-        "units": {
-          "en": "min.",
-          "nl": "min."
+        "attr": { "min": 0, "max": 4 },
+        "hint": {
+          "en": "Change the mode/sensitivity between 5 modes"
         }
       },
       {
-        "id": "sensorSensitivity",
-        "type": "dropdown",
-        "label": {
-          "en": "Pet Immunity",
-          "nl": "Huisdier detectie immuniteit"
-        },
+        "id": "anyMotionThreshold",
+        "label": { "en": "Detection Threshold" },
+        "zwave": { "index": 10, "size": 1 },
+        "type": "number",
+        "value": 128,
+        "attr": { "min": 0, "max": 255 }
+      }
+    ]
+  },
+  {
+    "type": "group",
+    "label": { "en": "Motion Reset Delays" },
+    "children": [
+      {
+        "id": "standardClearDelay",
+        "label": { "en": "Standard Reset Delay" },
+        "zwave": { "index": 8, "size": 1 },
+        "type": "number",
+        "value": 10,
+        "attr": { "min": 10, "max": 255 },
+        "units": { "en": "seconds" },
         "hint": {
-          "en": "Configures the “Pet Immunity,” or sensitivity of the motion detection used mostly so only human motion is detected.\n\nDefault: 15kg (33lb)",
-          "nl": "Configures the “Pet Immunity,” or sensitivity of the motion detection used mostly so only human motion is detected.\n\nDefault: 15kg (33lb)"
-        },
-        "value": "1",
-        "values": [
-          {
-            "id": "0",
-            "label": {
-              "en": "No pet immunity"
-            }
-          },
-          {
-            "id": "1",
-            "label": {
-              "en": "15kg (33lb)"
-            }
-          },
-          {
-            "id": "2",
-            "label": {
-              "en": "25kg (55lb)"
-            }
-          }
-        ]
+          "en": "Delay time in seconds for standard motion signal to clear.\n\nDefault: 10 sec."
+        }
       },
       {
-        "id": "batteryReportInterval",
-        "zwave": {
-          "index": 1,
-          "size": 2
-        },
+        "id": "occupancyClearDelay",
+        "label": { "en": "Occupancy Reset Delay" },
+        "zwave": { "index": 6, "size": 1 },
         "type": "number",
-        "value": 4200,
-        "attr": {
-          "min": 255,
-          "max": 4200
-        },
-        "units": {
-           "en": "sec.",
-           "nl": "sec."
-        },
-        "label": {
-          "en": "Battery Report Interval",
-          "nl": "Battery Rapporttage Interval"      
-        },
+        "value": 5,
+        "attr": { "min": 0, "max": 255 },
+        "units": { "en": "seconds" },
         "hint": {
-          "en": "The interval between battery reports. \n\nDefault: 4200 seconds (70 minuten).",
-          "nl": "De tijdsduur tussen batterij rapporten. \n\nStandaard: 4200 seconds (70 minuten)."
-        },     
-        "_size": 2
+          "en": "Delay time in seconds for occupancy signal to clear.\n\nDefault: 0 sec."
+        }
+      },
+      {
+        "id": "intrusionClearDelay",
+        "label": { "en": "Intrusion Reset Delay" },
+        "zwave": { "index": 7, "size": 1 },
+        "type": "number",
+        "value": 5,
+        "attr": { "min": 5, "max": 255 },
+        "units": { "en": "seconds" },
+        "hint": {
+          "en": "Delay time in seconds for intrusion signal to clear.\n\nDefault: 5 sec."
+        }
+      }
+    ]
+  },
+  {
+    "type": "group",
+    "label": { "en": "LED Notifications" },
+    "children": [
+      {
+        "id": "lightingEnabled",
+        "label": { "en": "Enabled on Detection" },
+        "zwave": { "index": 11, "size": 1 },
+        "type": "Checkbox",
+        "value": false,
+        "hint": {
+          "en": "When enabled the LED light will turn green when motion is detected."
+        }
+      },
+      {
+        "id": "lightingDelay",
+        "label": { "en": "Turn Off Delay" },
+        "zwave": { "index": 12, "size": 1 },
+        "type": "number",
+        "units": { "en": "seconds" },
+        "attr": { "min": 0, "max": 255 },
+        "value": false,
+        "hint": {
+          "en": "Delay in seconds after which the LED light will turn off."
+        }
+      }
+    ]
+  },
+  {
+    "type": "group",
+    "label": { "en": "Power" },
+    "children": [
+      {
+        "id": "heartbeatInterval",
+        "label": { "en": "Battery Report Interval" },
+        "zwave": { "index": 1, "size": 1 },
+        "type": "number",
+        "value": 70,
+        "attr": { "min": 1, "max": 70 },
+        "units": { "en": "minutes" },
+        "hint": { "en": "The interval between battery level reports. \n\nDefault: 70 minutes." }
       }
     ]
   }
-
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,56 +1,71 @@
 {
   "name": "com.ring.security",
   "version": "0.2.15",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/homey": {
-      "version": "npm:homey-apps-sdk-v3-types@0.1.0",
-      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.1.0.tgz",
-      "integrity": "sha512-6oafbv/9Tj7CbDONWVW88owHGxb7GsZZIg3VsL2UEccadfqf6f3jCoRGEgS94V1bkclNN+TKdfAOWEPpOIOt1A==",
+  "packages": {
+    "": {
+      "name": "com.ring.security",
+      "version": "0.2.15",
+      "dependencies": {
+        "homey-zwavedriver": "^2.2.0"
+      },
+      "devDependencies": {
+        "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.5"
+      }
+    },
+    "node_modules/@types/homey": {
+      "name": "homey-apps-sdk-v3-types",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.5.tgz",
+      "integrity": "sha512-AH7UPiPILITBmjDSAnupLp2kaBO9GuAj5y0hk9tLC2mO0AuOQuRYnbXIxrHOG3kium8m99FnS3BUHg0aY/SNCg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "@types/node": "^14.14.20"
       }
     },
-    "@types/node": {
+    "node_modules/@types/node": {
       "version": "14.14.37",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
       "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
       "dev": true
     },
-    "almost-equal": {
+    "node_modules/almost-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
       "integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0="
     },
-    "color-space": {
+    "node_modules/color-space": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
       "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
-      "requires": {
+      "dependencies": {
         "hsluv": "^0.0.3",
         "mumath": "^3.3.4"
       }
     },
-    "homey-zwavedriver": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/homey-zwavedriver/-/homey-zwavedriver-2.1.0.tgz",
-      "integrity": "sha512-hOfUWWO1Hq1fmtauok4hMd2gEE7KMJmt2S2pYTOwpTFvisuR4teeX3vfbFqTxw4fSSThoKitoM3lWqUSomQc8g==",
-      "requires": {
+    "node_modules/homey-zwavedriver": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/homey-zwavedriver/-/homey-zwavedriver-2.2.0.tgz",
+      "integrity": "sha512-hPLKP6uOvaaMgjPFOBcal4xoFQifntOatoKsv8yEQBEAddk0iv5b9phIXxpdeAY1nMQyd/EPQivHhq6vEfb7sw==",
+      "dependencies": {
         "color-space": "^1.16.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "hsluv": {
+    "node_modules/hsluv": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
       "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw="
     },
-    "mumath": {
+    "node_modules/mumath": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
       "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
-      "requires": {
+      "deprecated": "Redundant dependency in your project.",
+      "dependencies": {
         "almost-equal": "^1.1.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.2.15",
   "main": "app.js",
   "devDependencies": {
-    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.1.0"
+    "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.5"
   },
   "dependencies": {
-    "homey-zwavedriver": "^2.1.0"
+    "homey-zwavedriver": "^2.2.0"
   }
 }


### PR DESCRIPTION
This PR addresses an issue in the compose configuration of the second gen motion sensor which does not describe the correct parameters. It also fixes the instructions for adding the device to the network which were not correct.

The settings defined are those from the V1 motion sensor none of which apply to the V2 motion sensor, various parameters such as the `alarmMotionResetWindow` are not bound to a zwave.

All parameters and defaults in this PR are taken from the zwave specification for the second gen motion sensor.

Note all settings are described in `en` only, some more obscure parameters were left out.